### PR TITLE
getContentsに_idを追加

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -67,7 +67,7 @@ export const fetchArticles = async (options?: {
       depth: 2,
       limit: _limit,
       order: ["sortOrder"],
-      select: ["title", "category", "slug", "body"],
+      select: ["title", "category", "slug", "body", "_id"],
       ..._query,
     },
   });


### PR DESCRIPTION
mapで記事一覧取得をkey={article._id}で取得する際、`_id`を使用していますが、フェッチされておらず、keypropエラー出ていました。

`Warning: Each child in a list should have a unique "key" prop.`

## 修正内容
getContentsのselectに_idを追加